### PR TITLE
Change @_env to local variable

### DIFF
--- a/lib/sshkit/backends/abstract.rb
+++ b/lib/sshkit/backends/abstract.rb
@@ -83,12 +83,11 @@ module SSHKit
       end
 
       def with(environment, &_block)
-        @_env = (@env ||= {})
-        @env = @_env.merge environment
+        _env = (@env ||= {})
+        @env = _env.merge environment
         yield
       ensure
-        @env = @_env
-        remove_instance_variable(:@_env)
+        @env = _env
       end
 
       def as(who, &_block)


### PR DESCRIPTION
In the SSHKit Abstract backend, the 'with' method declared an instance variable (@_env) that was only used in that method, and ensured it was unset before returning. This would cause errors when nesting 'with' calls, as the outer call would try to use and then unset @_env after the inner call already unset it. It has been changed to a regular local variable, as the desired behaviour is identical to using a local variable anyway.

This fixes Issue #43 and Issue #176
